### PR TITLE
Add form factors to desktop and appdata files

### DIFF
--- a/data/org.emilien.Password.desktop.in
+++ b/data/org.emilien.Password.desktop.in
@@ -6,3 +6,4 @@ Type=Application
 Categories=GTK;;GNOME;Utility;
 StartupNotify=true
 Icon=org.emilien.Password
+X-Purism-FormFactor=Workstation;Mobile;

--- a/data/org.emilien.Password.metainfo.xml.in
+++ b/data/org.emilien.Password.metainfo.xml.in
@@ -56,5 +56,9 @@
   <project_group>GNOME</project_group>
   <translation type="gettext">password</translation>
   <content_rating type="oars-1.0" />
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
 </component>
 


### PR DESCRIPTION
This makes the app visible in the PureOS Store on the Librem 5.

See https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/